### PR TITLE
fix(frontend): default to Light theme and persist preference in localStorage

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,11 +7,16 @@ import About from './pages/About'
 import './App.css'
 
 export default function App() {
-  const [dark, setDark] = useState(() => window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const [dark, setDark] = useState(() => {
+    const saved = localStorage.getItem('theme')
+    if (saved) return saved === 'dark'
+    return false // default: Light
+  })
   const path = window.location.pathname
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', dark)
+    localStorage.setItem('theme', dark ? 'dark' : 'light')
   }, [dark])
 
   const isChat = path === '/chat'


### PR DESCRIPTION
## 📋 Description

<!-- Clearly describe what this PR does and why. Link to any relevant issue or discussion. -->

Fixes two related theme bugs: 

- the app was initialising in Dark mode on first load
- any manual theme change was lost when navigating between pages.

Closes #23 

---

## 🔄 Type of Change

<!-- Check all that apply -->

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧠 Model / RAG improvement
- [ ] 📚 Knowledge base update
- [ ] 🔧 Refactor / code quality
- [ ] 📝 Documentation
- [ ] 🧪 Tests
- [ ] ⚙️ CI/CD / infrastructure
- [ ] 🔒 Security fix

---

## 🧪 How Has This Been Tested?

<!-- Describe the tests you ran. Include any relevant details (model used, sample queries, etc.) -->

- [ ] Unit tests pass (`pytest tests/`)
- [X] Manual chat testing with sample queries

**Sample queries tested:**
```
Open app with no prior localStorage entry → loads in Light mode
Toggle to Dark → navigate to /chat → theme stays Dark
Toggle to Light → refresh page → theme stays Light
```

**Observed chatbot responses:**
<!-- Paste or describe the outputs -->

---

## 📸 Screenshots / Demo

<!-- If UI or response quality changed, add screenshots or example outputs -->

---

## ✅ Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have added/updated docstrings and comments where needed
- [ ] I have updated relevant documentation in `/docs`
- [x] No secrets, API keys, or sensitive university data are committed
- [x] I have not committed raw PII or student data
- [x] New dependencies are justified and added to `requirements.txt` / `pyproject.toml`
- [x] My changes do not degrade response quality on existing test queries

---

## 🌍 Language / Localization Notes

<!-- Does this affect Bulgarian language handling, transliteration, or responses in BG/EN? -->

- [ ] Bulgarian language responses affected
- [x] No language impact

---

## 💬 Additional Notes for Reviewers

<!-- Anything specific reviewers should focus on, or known limitations -->

Only `App.jsx` was touched — two changes:
1. `useState` initialiser reads `localStorage` first, falls back to `false` (Light)
2. `useEffect` now also calls `localStorage.setItem` alongside the existing `classList.toggle`

Same pattern already used by the i18n language preference.